### PR TITLE
Support spaces in paths

### DIFF
--- a/buildroot/share/PlatformIO/scripts/et4.py
+++ b/buildroot/share/PlatformIO/scripts/et4.py
@@ -15,6 +15,6 @@ env.AddPostAction(
     "$BUILD_DIR/${PROGNAME}.elf",
     env.VerboseAction(" ".join([
         "$OBJCOPY", "-O", "srec", 
-        "$BUILD_DIR/${PROGNAME}.elf", "$BUILD_DIR/${PROGNAME}.srec"
+        "\"$BUILD_DIR/${PROGNAME}.elf\"", "\"$BUILD_DIR/${PROGNAME}.srec\""
     ]), "Building " + join("$BUILD_DIR","${PROGNAME}.srec"))
 )


### PR DESCRIPTION
### Description

When the srec file construction operation is performed, it fails if the project path contains a blank space.

### Benefits

Users who have spaces in their Marlin folder will be able to compile without problems.
